### PR TITLE
skip strcpy in case of same source and destination

### DIFF
--- a/libsofd.c
+++ b/libsofd.c
@@ -1252,7 +1252,8 @@ static int fib_opendir (Display *dpy, const char* path, const char *sel) {
 	} else {
 		int i;
 		struct dirent *de;
-		strcpy (_cur_path, path);
+		if (path != _cur_path)
+			strcpy (_cur_path, path);
 
 		if (_cur_path[strlen (_cur_path) -1] != '/')
 			strcat (_cur_path, "/");


### PR DESCRIPTION
Hi, usage of `strcpy` is undefined resulting from this call of fib_opendir.
https://github.com/x42/sofd/blob/6a21040774bac54661e8168234751bd88d952132/libsofd.c#L2047